### PR TITLE
Explictly import carla_backend

### DIFF
--- a/src/claudia_launcher.py
+++ b/src/claudia_launcher.py
@@ -39,6 +39,7 @@ from shared import *
 # Imports (Carla)
 
 try:
+    from carla_backend import *
     from carla_utils import *
     haveCarla = True
 except:


### PR DESCRIPTION
On my systems this is required otherwise python complains that PLUGIN_CATEGORY_* and PLUGIN_HAS_* are undefined

Fixes issue #320